### PR TITLE
Require login before accessing admin dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ A simple FastAPI application for aggregating and embedding calendars.
 
 Set the `ADMIN_USERNAME` and `ADMIN_PASSWORD` environment variables. To obtain an admin token, send a `POST` request to `/admin/login` with form fields `username` and `password`. The endpoint returns JSON containing a `token` value.
 
-Include this token in subsequent admin requests either as a query parameter `?token=YOUR_TOKEN` or as an `X-Admin-Token` header. The admin dashboard at `/admin` provides a login form and stores the token for later requests.
+Include this token in subsequent admin requests either as a query parameter `?token=YOUR_TOKEN` or as an `X-Admin-Token` header. Visiting the site root `/` shows a login form that will authenticate and redirect to the dashboard at `/admin`.
 

--- a/app/main.py
+++ b/app/main.py
@@ -77,13 +77,17 @@ def make_slug(text: str) -> str:
     """Create a slug from text using the python-slugify library."""
     return slugify(text)
 
+# Public login page
 @app.get("/", response_class=HTMLResponse)
-async def root(request: Request):
-    return RedirectResponse(url="/admin")
+async def root():
+    """Show the admin login form."""
+    with open("templates/login.html", "r", encoding="utf-8") as f:
+        return HTMLResponse(f.read())
 
 # Admin dashboard
 @app.get("/admin", response_class=HTMLResponse)
 async def admin_page(request: Request, session: Session = Depends(get_session)):
+    require_admin(request)
     calendars = session.exec(select(Calendar).order_by(Calendar.name)).all()
     token = request.query_params.get("token") or request.headers.get("X-Admin-Token")
     with open("templates/admin.html", "r", encoding="utf-8") as f:

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Calendar Hub Login</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="/static/styles.css">
+</head>
+<body>
+  <main class="wrap">
+    <section class="card">
+      <h2>Admin Login</h2>
+      <form id="login-form">
+        <label>Username <input name="username" required></label>
+        <label>Password <input type="password" name="password" required></label>
+        <div class="right"><button type="submit">Login</button></div>
+      </form>
+    </section>
+  </main>
+  <script>
+    const stored = localStorage.getItem('adminToken');
+    if (stored) {
+      window.location = `/admin?token=${stored}`;
+    }
+    const loginForm = document.getElementById('login-form');
+    if (loginForm) {
+      loginForm.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const formData = new FormData(loginForm);
+        const resp = await fetch('/admin/login', {
+          method: 'POST',
+          body: new URLSearchParams(formData)
+        });
+        if (resp.ok) {
+          const data = await resp.json();
+          localStorage.setItem('adminToken', data.token);
+          window.location = `/admin?token=${data.token}`;
+        } else {
+          alert('Login failed');
+        }
+      });
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Serve a dedicated login page at site root and redirect to admin after authentication
- Require admin token to view dashboard
- Document new login flow

## Testing
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4e57d65708323964cea9112b89759