### PR TITLE
feat: enhance calendar embed customization

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -32,12 +32,20 @@
             <label>Slug <input id="slug" name="slug" placeholder="auto-from-name"></label>
             <label>Incoming ICS URL <input name="incoming_ics_url" placeholder="https://.../calendar.ics"></label>
             <label>Timezone <input name="timezone" value="America/New_York"></label>
-            <label>Default View
-              <select name="default_view">
+            <label>Desktop Default View
+              <select name="desktop_view">
                 <option value="dayGridMonth">Month</option>
                 <option value="timeGridWeek">Week</option>
                 <option value="timeGridDay">Day</option>
                 <option value="listWeek">List</option>
+              </select>
+            </label>
+            <label>Mobile Default View
+              <select name="mobile_view">
+                <option value="dayGridMonth">Month</option>
+                <option value="timeGridWeek">Week</option>
+                <option value="timeGridDay">Day</option>
+                <option value="listWeek" selected>List</option>
               </select>
             </label>
           </div>
@@ -50,6 +58,8 @@
             <label>Background Color <input name="background_color" type="color" value="#ffffff"></label>
             <label>Logo URL <input name="logo_url" placeholder="https://.../logo.png"></label>
             <label>Upload Logo (optional) <input type="file" name="logo_file" accept="image/*"></label>
+            <label>Logo Height (px) <input name="logo_height" type="number" value="40"></label>
+            <label><input type="checkbox" name="show_name" value="1" checked> Show Calendar Name</label>
           </div>
         </fieldset>
         <div class="right">

--- a/templates/embed.html
+++ b/templates/embed.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>{{NAME}}</title>
+  <title>{{TITLE_TEXT}}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.15/index.global.min.css" rel="stylesheet">
   <link rel="stylesheet" href="/static/styles.css">
@@ -13,7 +13,8 @@
       --bg: {{BG}};
     }
     body{background-color: var(--bg);}
-    .logo{height:40px; object-fit:contain}
+    .logo{height:{{LOGO_HEIGHT}}px; object-fit:contain}
+    header.bar{background-color:var(--primary);color:#fff}
     .wrap{max-width:1100px;margin:8px auto;padding:0 12px}
   </style>
 </head>
@@ -21,8 +22,8 @@
   <div class="wrap">
     <header class="bar">
       <div class="left">
-        {% if "{{LOGO_URL}}" %}<img class="logo" src="{{LOGO_URL}}" alt="{{NAME}} logo">{% endif %}
-        <h1 style="margin-left:8px">{{NAME}}</h1>
+        {{LOGO}}
+        {{TITLE}}
       </div>
       <div class="muted">{{TZ}}</div>
     </header>
@@ -36,12 +37,16 @@
     document.addEventListener('DOMContentLoaded', function() {
       const el = document.getElementById('calendar');
       const isMobile = window.matchMedia('(max-width: 768px)').matches;
-      const initialView = isMobile ? 'listWeek' : '{{VIEW}}';
+      const initialView = isMobile ? '{{MOBILE_VIEW}}' : '{{DESKTOP_VIEW}}';
+      const headerDesktop = { left: 'prev,next today', center: 'title', right: 'dayGridMonth,timeGridWeek,timeGridDay,listWeek' };
+      const headerMobile = { center: 'title', left: '', right: '' };
+      const footerMobile = { left: 'prev,next today', right: 'dayGridMonth,timeGridWeek,timeGridDay,listWeek' };
 
       const calendar = new FullCalendar.Calendar(el, {
         themeSystem: 'standard',
         initialView,
-        headerToolbar: { left: 'prev,next today', center: 'title', right: 'dayGridMonth,timeGridWeek,timeGridDay,listWeek' },
+        headerToolbar: isMobile ? headerMobile : headerDesktop,
+        footerToolbar: isMobile ? footerMobile : undefined,
         height: 'auto',
         nowIndicator: true,
         eventDisplay: 'block',


### PR DESCRIPTION
## Summary
- allow independent desktop and mobile views
- let admins size logos and toggle calendar names
- apply primary color to header and fix logo placeholder so embeds populate

## Testing
- `python -m py_compile app/main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4f3e27b5c832391e115c349e1eb7d