### PR TITLE
Enable calendar editing and apply theme colors to calendar UI

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -1,4 +1,4 @@
-body{margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#222;background:#fff}
+body{margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:var(--text,#222);background:var(--bg,#fff)}
 .bar{display:flex;align-items:center;justify-content:space-between;padding:10px 12px;border-bottom:1px solid #eee}
 .left{display:flex;align-items:center}
 .wrap{max-width:1100px;margin:0 auto;padding:12px}
@@ -10,4 +10,8 @@ button{background:var(--primary,#0b9444);color:#fff;border:0;cursor:pointer}
 button:hover{opacity:.95}
 table{width:100%;border-collapse:collapse}
 th,td{padding:8px;border-bottom:1px solid #eee;font-size:14px}
+.fc .fc-button-primary{background:var(--primary,#0b9444);border-color:var(--primary,#0b9444);color:#fff}
+.fc .fc-button-primary:hover{background:var(--accent,#0bd3d3);border-color:var(--accent,#0bd3d3)}
+.fc-theme-standard td,.fc-theme-standard th{border-color:var(--accent,#0bd3d3)}
+.fc-theme-standard .fc-scrollgrid{border-color:var(--primary,#0b9444)}
 .muted{color:#666;font-size:12px}

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -56,6 +56,8 @@
             <label>Primary Color <input name="primary_color" type="color" value="#0b9444"></label>
             <label>Accent Color <input name="accent_color" type="color" value="#0bd3d3"></label>
             <label>Background Color <input name="background_color" type="color" value="#ffffff"></label>
+            <label>Text Color <input name="text_color" type="color" value="#222222"></label>
+            <label>Title Color <input name="title_color" type="color" value="#ffffff"></label>
             <label>Logo URL <input name="logo_url" placeholder="https://.../logo.png"></label>
             <label>Upload Logo (optional) <input type="file" name="logo_file" accept="image/*"></label>
             <label>Logo Height (px) <input name="logo_height" type="number" value="40"></label>

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Edit Calendar</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="/static/styles.css">
+</head>
+<body>
+  <main class="wrap">
+    <h2>Edit calendar</h2>
+    <form method="post" action="/admin/edit/{{SLUG}}{{TOKEN_PARAM}}" enctype="multipart/form-data">
+      <fieldset>
+        <legend>Calendar Config</legend>
+        <div class="grid">
+          <label>Name <input name="name" value="{{NAME}}" required></label>
+          <label>Slug <input name="slug" value="{{SLUG}}" readonly></label>
+          <label>Incoming ICS URL <input name="incoming_ics_url" value="{{ICS}}"></label>
+          <label>Timezone <input name="timezone" value="{{TZ}}"></label>
+          <label>Desktop Default View
+            <select name="desktop_view">
+              <option value="dayGridMonth" {{DESKTOP_MONTH}}>Month</option>
+              <option value="timeGridWeek" {{DESKTOP_WEEK}}>Week</option>
+              <option value="timeGridDay" {{DESKTOP_DAY}}>Day</option>
+              <option value="listWeek" {{DESKTOP_LIST}}>List</option>
+            </select>
+          </label>
+          <label>Mobile Default View
+            <select name="mobile_view">
+              <option value="dayGridMonth" {{MOBILE_MONTH}}>Month</option>
+              <option value="timeGridWeek" {{MOBILE_WEEK}}>Week</option>
+              <option value="timeGridDay" {{MOBILE_DAY}}>Day</option>
+              <option value="listWeek" {{MOBILE_LIST}}>List</option>
+            </select>
+          </label>
+        </div>
+      </fieldset>
+      <fieldset>
+        <legend>Calendar Customization</legend>
+        <div class="grid">
+          <label>Primary Color <input name="primary_color" type="color" value="{{PRIMARY}}"></label>
+          <label>Accent Color <input name="accent_color" type="color" value="{{ACCENT}}"></label>
+          <label>Background Color <input name="background_color" type="color" value="{{BG}}"></label>
+          <label>Text Color <input name="text_color" type="color" value="{{TEXT_COLOR}}"></label>
+          <label>Title Color <input name="title_color" type="color" value="{{TITLE_COLOR}}"></label>
+          <label>Logo URL <input name="logo_url" value="{{LOGO_URL}}"></label>
+          <label>Upload Logo (optional) <input type="file" name="logo_file" accept="image/*"></label>
+          <label>Logo Height (px) <input name="logo_height" type="number" value="{{LOGO_HEIGHT}}"></label>
+          <label><input type="checkbox" name="show_name" value="1" {{SHOW_NAME_CHECKED}}> Show Calendar Name</label>
+        </div>
+      </fieldset>
+      <div class="right">
+        <button type="submit">Save</button>
+      </div>
+    </form>
+  </main>
+</body>
+</html>

--- a/templates/embed.html
+++ b/templates/embed.html
@@ -11,10 +11,12 @@
       --primary: {{PRIMARY}};
       --accent: {{ACCENT}};
       --bg: {{BG}};
+      --text: {{TEXT_COLOR}};
+      --title: {{TITLE_COLOR}};
     }
-    body{background-color: var(--bg);}
+    body{background-color: var(--bg); color: var(--text);}
     .logo{height:{{LOGO_HEIGHT}}px; object-fit:contain}
-    header.bar{background-color:var(--primary);color:#fff}
+    header.bar{background-color:var(--primary);color:var(--title)}
     .wrap{max-width:1100px;margin:8px auto;padding:0 12px}
   </style>
 </head>
@@ -52,6 +54,8 @@
         eventDisplay: 'block',
         eventColor: getComputedStyle(document.documentElement).getPropertyValue('--primary'),
         eventBorderColor: getComputedStyle(document.documentElement).getPropertyValue('--accent'),
+        eventTextColor: getComputedStyle(document.documentElement).getPropertyValue('--text'),
+        titleColor: getComputedStyle(document.documentElement).getPropertyValue('--title'),
         timeZone: '{{TZ}}',
         events: [{
           url: '/api/cal/{{SLUG}}/ics',


### PR DESCRIPTION
## Summary
- add `/admin/edit/<slug>` interface to update existing calendars
- allow editing from dashboard and save changes back to database
- apply custom primary, accent, background, text, and title colors to FullCalendar buttons, grid, and text

## Testing
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4f84c53d083239f6788b81641fcd5