### PR TITLE
Fix calendar assets over HTTPS behind proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,5 @@ Then add a container and load the calendar-specific script:
 
 The loader injects the calendar markup into `#calendar-container` and uses the loaded FullCalendar libraries to render events.
 
+When running behind a reverse proxy, ensure it sets the `X-Forwarded-Proto` header so embedded assets use the correct scheme. If you include the `<script>` tag in the `<head>`, add the `defer` attribute (instead of `async`) to ensure the calendar container exists before the loader executes.
+

--- a/app/main.py
+++ b/app/main.py
@@ -336,7 +336,9 @@ async def embed_script(request: Request, slug: str, session: Session = Depends(g
     if not cal:
         raise HTTPException(status_code=404, detail="Calendar not found")
 
-    base = str(request.base_url).rstrip("/")
+    scheme = request.headers.get("x-forwarded-proto", request.url.scheme)
+    host = request.headers.get("x-forwarded-host", request.url.netloc)
+    base = f"{scheme}://{host}".rstrip("/")
     logo_url = ""
     if cal.logo_url:
         if cal.logo_url.startswith("http://") or cal.logo_url.startswith("https://"):
@@ -405,7 +407,9 @@ async def embed_code(request: Request, slug: str, session: Session = Depends(get
     cal = session.exec(select(Calendar).where(Calendar.slug == slug)).first()
     if not cal:
         raise HTTPException(status_code=404, detail="Calendar not found")
-    base = str(request.base_url).rstrip("/")
+    scheme = request.headers.get("x-forwarded-proto", request.url.scheme)
+    host = request.headers.get("x-forwarded-host", request.url.netloc)
+    base = f"{scheme}://{host}".rstrip("/")
     iframe_src = f"{base}/c/{cal.slug}/embed"
     iframe_code = (
         f"<iframe src=\"{iframe_src}\" style=\"border:0;width:100%;height:600px\"></iframe>"


### PR DESCRIPTION
## Summary
- Respect `X-Forwarded-Proto`/`X-Forwarded-Host` headers when generating embed URLs so assets match the client scheme
- Document proxy header requirement and using `defer` in README

## Testing
- `python -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68a50c511c6c8323b8d5192f357e8365