### PR TITLE
Fix unmatched brace in embed script causing syntax error

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -407,9 +407,9 @@ async def embed_script(request: Request, slug: str, session: Session = Depends(g
     }} else {{
       init();
     }}
-  })();
+  }})();
   """
-      return PlainTextResponse(js, media_type="text/javascript")
+    return PlainTextResponse(js, media_type="text/javascript")
 
 
 @app.get("/admin/embed-code/{slug}", response_class=HTMLResponse)


### PR DESCRIPTION
## Summary
- Escape final closing brace in generated embed script to prevent syntax error during import

## Testing
- `python -m py_compile app/main.py`
- `python - <<'PY'
import app.main
print('import succeeded')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a5160387848323956d62e05195d7b2