### PR TITLE
fix: remove unsupported titleColor option

### DIFF
--- a/templates/embed.html
+++ b/templates/embed.html
@@ -55,7 +55,6 @@
         eventColor: getComputedStyle(document.documentElement).getPropertyValue('--primary'),
         eventBorderColor: getComputedStyle(document.documentElement).getPropertyValue('--accent'),
         eventTextColor: getComputedStyle(document.documentElement).getPropertyValue('--text'),
-        titleColor: getComputedStyle(document.documentElement).getPropertyValue('--title'),
         timeZone: '{{TZ}}',
         eventSources: [{
           url: '/api/cal/{{SLUG}}/ics',


### PR DESCRIPTION
## Summary
- remove unsupported titleColor option from embed template to avoid FullCalendar initialization issues

## Testing
- `python3 -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68a5d8125f608323bf5bcd523ef7dd5f