### PR TITLE
fix: enable ical plugin for calendar

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -399,7 +399,7 @@ async def embed_script(request: Request, slug: str, session: Session = Depends(g
     const headerMobile={{ center:'title', left:'', right:'' }};
     const footerMobile={{ left:'prev,next today', right:'dayGridMonth,timeGridWeek,timeGridDay,listWeek' }};
     const colors=getComputedStyle(container);
-    const calendar=new FullCalendar.Calendar(el,{{themeSystem:'standard',initialView,headerToolbar:isMobile?headerMobile:headerDesktop,footerToolbar:isMobile?footerMobile:undefined,height:'auto',nowIndicator:true,eventDisplay:'block',eventColor:colors.getPropertyValue('--primary'),eventBorderColor:colors.getPropertyValue('--accent'),eventTextColor:colors.getPropertyValue('--text'),timeZone:'{cal.timezone}',eventSources:[{{url:'{ics_url}',format:'ics'}}]}});
+    const calendar=new FullCalendar.Calendar(el,{{plugins:[FullCalendar.icalendarPlugin],themeSystem:'standard',initialView,headerToolbar:isMobile?headerMobile:headerDesktop,footerToolbar:isMobile?footerMobile:undefined,height:'auto',nowIndicator:true,eventDisplay:'block',eventColor:colors.getPropertyValue('--primary'),eventBorderColor:colors.getPropertyValue('--accent'),eventTextColor:colors.getPropertyValue('--text'),timeZone:'{cal.timezone}',eventSources:[{{url:'{ics_url}',format:'ics'}}]}});
     calendar.render();
     }}
     if (document.readyState === 'loading') {{

--- a/templates/embed.html
+++ b/templates/embed.html
@@ -45,6 +45,7 @@
       const footerMobile = { left: 'prev,next today', right: 'dayGridMonth,timeGridWeek,timeGridDay,listWeek' };
 
       const calendar = new FullCalendar.Calendar(el, {
+        plugins: [ FullCalendar.icalendarPlugin ],
         themeSystem: 'standard',
         initialView,
         headerToolbar: isMobile ? headerMobile : headerDesktop,


### PR DESCRIPTION
## Summary
- load FullCalendar iCalendar plugin for embedded calendars
- include iCalendar plugin when generating JS loader

## Testing
- `python -m py_compile app/main.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5dcfc2398832391f04c99e6d82614